### PR TITLE
license switch to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,9 @@
-           DO WHAT THE FUCK YOU WANT TO PUBLIC LICENCE
-                   Version 3.1, July 2019
+MIT No Attribution License
 
-  by Sam Hocevar  <sam@hocevar.net>
-     theiostream  <matoe@matoe.co.cc>
-     dtf          <wtfpl@dtf.wtf>
+Copyright (c) 2022 Konstantin Pogorelov
 
-           DO WHAT THE FUCK YOU WANT TO PUBLIC LICENCE
-  TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.
 
-  0. You just DO WHAT THE FUCK YOU WANT TO.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+

--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ const parser = new UrlValueParser({
 
 ## License
 
-WTFPL
+MIT No Attribution License

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "url-value-parser",
       "version": "2.0.3",
-      "license": "WTFPL",
+      "license": "MIT-0",
       "devDependencies": {
         "coveralls": "^3.0.2",
         "eslint": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "./node_modules/jasme/run.js"
   },
   "author": "Konstantin Pogorelov <or@pluseq.com>",
-  "license": "WTFPL",
+  "license": "MIT-0",
   "repository": {
     "type": "git",
     "url": "https://github.com/disjunction/url-value-parser.git"


### PR DESCRIPTION
Please consider changing the license to the MIT license.
There are a lot of good legal reasons for that from the developer's point of view (e.g., https://news.ycombinator.com/item?id=18229988).
But also, many companies cannot use code under licenses that don't have the OSI blessing.
Anyhow, thank you for making your code open source :-)